### PR TITLE
Removed IN Reasons

### DIFF
--- a/pages/workspace/[id]/activity/index.tsx
+++ b/pages/workspace/[id]/activity/index.tsx
@@ -131,7 +131,7 @@ const Activity: pageWithLayout = () => {
 										key={user.userId}
 										tooltipText={
 											user.reason
-												? `${user.username} | ${moment(user.from).format("DD MMM")} - ${moment(user.to).format("DD MMM")} for ${user.reason}`
+												? `${user.username} | ${moment(user.from).format("DD MMM")} - ${moment(user.to).format("DD MMM")}`
 												: `${user.username}`
 										}
 										orientation="top"


### PR DESCRIPTION
Removed Inactivity Notice Reasons from activity page. Reasons may be personal sometimes and I do not think it should be shared with everyone on the workspace.

![image](https://github.com/user-attachments/assets/ef245363-7477-457c-a778-ab7efb135077)
