### PR TITLE
Update package.json - fixed build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
-    "lint": "next lint",
-    "prisma:generate": "prisma generate"
+    "lint": "next lint"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.18",


### PR DESCRIPTION
Fixed an issue with building where the build would fail because of prisma not being available in the build process; resolved by running `prisma generate` before proceeding with build