### PR TITLE
(Critical security vulnerability) Unauthenticated path traversal in avatar endpoint enables arbitrary file write & public file planting

### DIFF
--- a/pages/api/workspace/[id]/avatar/[userid]/index.ts
+++ b/pages/api/workspace/[id]/avatar/[userid]/index.ts
@@ -9,8 +9,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!userid || Array.isArray(userid)) {
     return res.status(400).end("Invalid userId");
   }
+  const numericUserId = Number(userid);
+  if (!Number.isInteger(numericUserId) || numericUserId <= 0) {
+    return res.status(400).end("Invalid userId");
+  }
 
-  const avatarPath = path.join(process.cwd(), "public", "avatars", `${userid}.png`);
+  const avatarPath = path.join(process.cwd(), "public", "avatars", `${numericUserId}.png`);
 
   try {
     if (!fs.existsSync(path.dirname(avatarPath))) {
@@ -23,7 +27,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return;
     }
 
-    const remoteUrl = await getRemoteAvatarUrl(Number(userid));
+    const remoteUrl = await getRemoteAvatarUrl(numericUserId);
     const response = await axios.get(remoteUrl, { responseType: "arraybuffer" });
     fs.writeFileSync(avatarPath, response.data);
 
@@ -32,7 +36,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.send(response.data);
   } catch (err) {
     try {
-      const remoteUrl = await getRemoteAvatarUrl(Number(userid));
+      const remoteUrl = await getRemoteAvatarUrl(numericUserId);
       const response = await axios.get(remoteUrl, { responseType: "arraybuffer" });
       res.setHeader("Content-Type", "image/png");
       res.send(response.data);


### PR DESCRIPTION
> **Severity:** [Critical](https://nvd.nist.gov/vuln-metrics/cvss#:~:text=Critical-,9.0%2D10.0,-Critical)
> **CVSS 3.1:** [9.1 (AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H)](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator)
> **CWE:** [CWE-22](https://cwe.mitre.org/data/definitions/22.html) (Path Traversal), [CWE-73](https://cwe.mitre.org/data/definitions/73.html) (External Control of File Name or Path)

## Summary
The `avatar` API used the user-controlled `userid` directly in a filesystem path, allowing `../` traversal and arbitrary file writes under the app root without authentication.

## Impact
* Arbitrary directories/files created under `public/` (defacement, spoofing).
* Integrity and availability risks via unwanted writes.

## Affected code
Path derived from unsanitized input (now fixed by integer-only validation and sanitized usage):
```ts
const numericUserId = Number(userid);

if (!Number.isInteger(numericUserId) || numericUserId <= 0) {
  return res.status(400).end("Invalid userId");
}

const avatarPath = path.join(process.cwd(), "public", "avatars", `${numericUserId}.png`);
```

## Steps to Reproduce (pre-fix)
* GET `/api/workspace/{any}/avatar/12345../../..` -> server wrote outside `public/avatars/`.
* Access planted file via the static server (e.g., `/evil/w.png`).

## Fix
* Validate `userid` as a positive integer; reject others.
* Use `numericUserId` for all filesystem paths and remote fetches.

## Why this fixes it
* Non-integer inputs (including `../`) are rejected.
* The file path is now constrained to `public/avatars/{id}.png`, eliminating traversal.