### PR TITLE
fix(security): atomically scope doc mutations to workspace to block IDOR

### DIFF
--- a/pages/api/workspace/[id]/guides/[docid]/delete.ts
+++ b/pages/api/workspace/[id]/guides/[docid]/delete.ts
@@ -18,19 +18,14 @@ export async function handler(
 ) {
 	if (req.method !== 'POST') return res.status(405).json({ success: false, error: 'Method not allowed' });
 	if (!req.query.docid) return res.status(400).json({ success: false, error: 'Document ID not provided' });
-	const doc = await prisma.document.findMany({
+	const workspaceId = parseInt(req.query.id as string);
+	const result = await prisma.document.deleteMany({
 		where: {
-			workspaceGroupId: parseInt(req.query.id as string),
-			id: (req.query.docid as string)
-		},
-	});
-	
-
-	await prisma.document.delete({
-		where: {
-			id: (req.query.docid as string)
+			id: (req.query.docid as string),
+			workspaceGroupId: workspaceId
 		}
 	});
+	if (result.count === 0) return res.status(404).json({ success: false, error: 'Document not found in this workspace' });
 
 	res.status(200).json({ success: true })
 }


### PR DESCRIPTION
This pull request resolves #79 by scoping document mutations to the current workspace and making the update atomic to eliminate IDOR/TOCTOU.