### PR TITLE
Fix default auth/workspace state initialization

### DIFF
--- a/state.ts
+++ b/state.ts
@@ -1,11 +1,10 @@
-import { atom, selector } from "recoil";
-import Router from "next/router";
-import { role } from "@prisma/client";
-import axios from "axios";
+import { atom } from "recoil";
+import type { role } from "@prisma/client";
+
 export type workspaceinfo = {
 	groupId: number;
-				groupThumbnail: string;
-				groupName: string
+	groupThumbnail: string;
+	groupName: string
 }
 
 export type LoginState = {
@@ -21,7 +20,7 @@ export type LoginState = {
 const loginState = atom<LoginState>({
 	key: "loginState",
 	default: {
-		userId: 1,
+		userId: 0,
 		username: '',
 		displayname: '',
 		thumbnail: '',
@@ -34,7 +33,9 @@ const loginState = atom<LoginState>({
 const workspacestate = atom({
 	key: "workspacestate",
 	default: {
-		groupId: typeof window !== 'undefined' ? parseInt(window.location.pathname.split('/')[2]) || 1 : 1,
+		groupId: typeof window !== "undefined"
+			? Number.parseInt(window.location.pathname.split("/")[2] ?? "", 10) || 0
+			: 0,
 		groupThumbnail: '',
 		groupName: '',
 		yourPermission: [] as string[],


### PR DESCRIPTION
- default loginState.userId/workspacestate.groupId now start at 0 to avoid impersonating user/workspace 1 -FlovereX
- Prisma role import is type-only -FlovereX
- npm run lint passes (existing exhaustive-deps warnings remain) -FlovereX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state initialization logic with more robust error handling and null-safety checks.
  * Extended state structure with additional configuration fields for theme, roles, and feature settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->