### PR TITLE
Potential fix for code scanning alert no. 204: Server-side request forgery

### DIFF
--- a/components/profile/notices.tsx
+++ b/components/profile/notices.tsx
@@ -307,8 +307,13 @@ const Notices: FC<Props> = ({ notices, canManageNotices = false, canApproveNotic
                     <button
                       onClick={async () => {
                         try {
-                          const workspaceId = router.query.id ?? workspace.groupId;
-                          await axios.post(`/api/workspace/${workspaceId}/activity/notices/update`, { id: notice.id, status: "cancel" });
+                          const routeWorkspaceId = Array.isArray(router.query.id) ? router.query.id[0] : router.query.id;
+                          const workspaceIdCandidate = routeWorkspaceId ?? workspace.groupId;
+                          const safeWorkspaceId =
+                            typeof workspaceIdCandidate === "string" && /^[A-Za-z0-9_-]{1,128}$/.test(workspaceIdCandidate)
+                              ? workspaceIdCandidate
+                              : workspace.groupId;
+                          await axios.post(`/api/workspace/${encodeURIComponent(safeWorkspaceId)}/activity/notices/update`, { id: notice.id, status: "cancel" });
                           setLocalNotices((prev) => prev.filter((n) => n.id !== notice.id));
                           toast.success("Notice revoked");
                         } catch (e) {


### PR DESCRIPTION
Potential fix for [https://github.com/PlanetaryOrbit/orbit/security/code-scanning/204](https://github.com/PlanetaryOrbit/orbit/security/code-scanning/204)

General fix: do not use raw `router.query` values directly in request URLs. Normalize and strictly validate the route parameter, and only use it if it matches an expected safe format; otherwise fall back to a trusted value or block the action.

Best fix here (without changing intended behavior): in `components/profile/notices.tsx`, sanitize `router.query.id` before building the URL. Since `router.query.id` can be `string | string[] | undefined`, first coerce to a single string, then validate with a strict allowlist regex (for example alphanumeric, `_`, `-`, length-bounded). Use the sanitized value if valid, otherwise use `workspace.groupId` (trusted state) and safely encode the final segment with `encodeURIComponent` when interpolating into the URL.

Changes needed in this file:
- In the revoke button `onClick` block around lines 310–311:
  - Replace direct assignment from `router.query.id ?? workspace.groupId` with validated coercion logic.
  - Build URL with encoded `safeWorkspaceId`.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
