### PR TITLE
Potential fix for code scanning alert no. 202: Server-side request forgery

### DIFF
--- a/components/sessioncard.tsx
+++ b/components/sessioncard.tsx
@@ -132,9 +132,16 @@ const SessionModal: React.FC<SessionModalProps> = ({
   const handleCancelSession = async () => {
     if (!cancelReason.trim()) return;
     try {
+      const workspaceIdRaw = Array.isArray(router.query.id) ? router.query.id[0] : router.query.id;
+      const workspaceId = typeof workspaceIdRaw === "string" ? workspaceIdRaw : "";
+      if (!/^[A-Za-z0-9_-]{1,64}$/.test(workspaceId)) {
+        toast.error("Invalid workspace id");
+        return;
+      }
+
       setIsCancelling(true);
       await axios.patch(
-        `/api/workspace/${router.query.id}/sessions/${session.id}/cancel`,
+        `/api/workspace/${workspaceId}/sessions/${session.id}/cancel`,
         { reason: cancelReason.trim() }
       );
       session.cancelled = true;


### PR DESCRIPTION
Potential fix for [https://github.com/PlanetaryOrbit/orbit/security/code-scanning/202](https://github.com/PlanetaryOrbit/orbit/security/code-scanning/202)

General fix: validate and constrain all user-derived URL components before building request paths. Never interpolate raw `router.query` values into request URLs.

Best fix here (without changing functionality): in `components/sessioncard.tsx`, normalize `router.query.id` to a single string and enforce a strict allowlist format (for example alphanumeric, `_`, `-`, length-bounded). If invalid, stop and show an error toast. Then use the validated value in the axios URL. This preserves the existing API call behavior for valid workspace IDs while blocking malicious/path-manipulating input.

Changes needed in shown region:
- In `handleCancelSession`, before `axios.patch(...)`, extract `workspaceIdRaw` from `router.query.id` safely (handle `string | string[] | undefined`).
- Validate with regex.
- Early return on invalid ID.
- Replace `${router.query.id}` with `${workspaceId}` in the URL.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cancellation validation to ensure workspace identifiers are properly validated before processing requests, with clearer error messaging for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->