### PR TITLE
Potential fix for code scanning alert no. 213: Server-side request forgery

### DIFF
--- a/pages/api/music/preview.ts
+++ b/pages/api/music/preview.ts
@@ -7,17 +7,35 @@ export default withSessionRoute(async function handler(req: NextApiRequest, res:
   if (!req.session.userid) return res.status(401).end();
 
   const url = req.query.url as string;
-  if (!url || !url.startsWith('https://audio-ssl.itunes.apple.com/')) {
+  if (!url) {
     return res.status(400).end('Invalid URL');
   }
 
-  const upstream = await axios.get(url, {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return res.status(400).end('Invalid URL');
+  }
+
+  if (
+    parsedUrl.protocol !== 'https:' ||
+    parsedUrl.hostname !== 'audio-ssl.itunes.apple.com' ||
+    parsedUrl.username ||
+    parsedUrl.password ||
+    (parsedUrl.port !== '' && parsedUrl.port !== '443')
+  ) {
+    return res.status(400).end('Invalid URL');
+  }
+
+  const upstream = await axios.get(parsedUrl.toString(), {
     responseType: 'stream',
     headers: {
       'User-Agent': 'Mozilla/5.0',
       'Accept': 'audio/*,*/*',
     },
     timeout: 15000,
+    maxRedirects: 0,
   });
 
   res.setHeader('Content-Type', upstream.headers['content-type'] || 'audio/mp4');


### PR DESCRIPTION
Potential fix for [https://github.com/PlanetaryOrbit/orbit/security/code-scanning/213](https://github.com/PlanetaryOrbit/orbit/security/code-scanning/213)

To fix this safely without changing intended behavior, validate the incoming `url` using the `URL` parser and enforce a strict allowlist on parsed components before calling `axios.get`:

- Parse `req.query.url` with `new URL(...)` inside a try/catch.
- Require:
  - `protocol === 'https:'`
  - `hostname === 'audio-ssl.itunes.apple.com'`
  - no credentials (`username`/`password` empty)
  - default HTTPS port only (`port === ''` or `443`)
- Use the parsed/normalized URL (`parsedUrl.toString()`) for the upstream request.
- Disable redirects (`maxRedirects: 0`) to prevent bypass via open redirects.
- Keep existing behavior for headers/streaming response.

All edits are in `pages/api/music/preview.ts`, around lines 9–21 where input validation and `axios.get` are currently done.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security validation for music preview requests to prevent unauthorized access and redirect attacks through stricter endpoint verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->