### PR TITLE
chore: remove unused recoil state in DiscordAuditLogging component

### DIFF
--- a/components/settings/general/externalLogging.tsx
+++ b/components/settings/general/externalLogging.tsx
@@ -1,6 +1,4 @@
 import { useState, useEffect } from "react";
-import { useRecoilState } from "recoil";
-import { workspacestate } from "@/state";
 import axios from "axios";
 import toast from "react-hot-toast";
 import { useRouter } from "next/router";
@@ -9,7 +7,6 @@ import Button from "@/components/button";
 import { ServiceCard, ServiceToggle } from "../instance/ServiceCard";
 
 function DiscordAuditLogging({ title = "Discord Logging" }: { title?: string }) {
-  const [workspace, setWorkspace] = useRecoilState(workspacestate);
   const router = useRouter();
   const [enabled, setEnabled] = useState(false);
   const [webhookUrl, setWebhookUrl] = useState("");


### PR DESCRIPTION
remove unused imports:
`import { useRecoilState } from "recoil";`
`import { workspacestate } from "@/state";`
and state hook:
`const [workspace, setWorkspace] = useRecoilState(workspacestate);`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state handling for Discord audit logging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->