### PR TITLE
Potential fix for code scanning alert no. 232: Server-side request forgery

### DIFF
--- a/pages/workspace/[id]/views.tsx
+++ b/pages/workspace/[id]/views.tsx
@@ -709,10 +709,22 @@ const Views: pageWithLayout<pageProps> = ({ isAdmin, hasManageViewsPerm, hasCrea
     }
   };
 
+  const getSafeWorkspaceId = (id: string | string[] | undefined) => {
+    if (typeof id !== "string") return null;
+    if (!/^[a-zA-Z0-9_-]+$/.test(id)) return null;
+    return id;
+  };
+
   useEffect(() => {
   }, [colFilters]);
 
   const massAction = () => {
+    const workspaceId = getSafeWorkspaceId(router.query.id);
+    if (!workspaceId) {
+      toast.error("Invalid workspace id.");
+      return;
+    }
+
     const selected = table.getSelectedRowModel().flatRows;
     const promises: any[] = [];
     for (const select of selected) {
@@ -720,7 +732,7 @@ const Views: pageWithLayout<pageProps> = ({ isAdmin, hasManageViewsPerm, hasCrea
 
       if (type == "add") {
         promises.push(
-          axios.post(`/api/workspace/${router.query.id}/activity/add`, {
+          axios.post(`/api/workspace/${workspaceId}/activity/add`, {
             userId: data.info.userId,
             minutes,
           })
@@ -728,7 +740,7 @@ const Views: pageWithLayout<pageProps> = ({ isAdmin, hasManageViewsPerm, hasCrea
       } else {
         promises.push(
           axios.post(
-            `/api/workspace/${router.query.id}/userbook/${data.info.userId}/new`,
+            `/api/workspace/${workspaceId}/userbook/${data.info.userId}/new`,
             { notes: message.length > 0 ? message : "Not provided.", type }
           )
         );


### PR DESCRIPTION
Potential fix for [https://github.com/PlanetaryOrbit/orbit/security/code-scanning/232](https://github.com/PlanetaryOrbit/orbit/security/code-scanning/232)

General fix: never interpolate raw `router.query` values directly into request URLs. Normalize query params to a single string and validate against a strict allowlist/pattern (and reject arrays/invalid characters) before building the path.

Best targeted fix in `pages/workspace/[id]/views.tsx`:
- Add a small helper to safely extract and validate `router.query.id` as a path-safe workspace ID.
- In `massAction`, resolve `workspaceId` once via the helper; if invalid, show an error and abort.
- Replace both URL templates using `router.query.id` with `workspaceId` (safe validated value).

This preserves functionality while removing tainted direct flow into axios URL construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation for workspace identifiers in mass actions
  * Invalid workspace data now triggers an error notification
  * Improved API request reliability through validated workspace handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->