### PR TITLE
changed from now to current

### DIFF
--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -255,7 +255,7 @@ const Topbar: NextPage = () => {
                                   </p>
                                   {s.isCurrent && (
                                     <span className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-400">
-                                      Now
+                                      Current
                                     </span>
                                   )}
                                 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the badge label in the Active sessions panel from "Now" to "Current" for clearer session identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanetaryOrbit/orbit/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->