### PR TITLE
Replace Discord Server Invite with working one

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Contributions are welcome and appreciated. Whether you're fixing a bug, improvin
 3. **Test** your changes locally before submitting.
 4. **Open a Pull Request** with a clear description of what you've changed and why.
 
-For bug reports and feature requests, please use our [feedback portal](https://feedback.planetaryapp.us/bugs). For questions and discussion, join our [Discord server](https://discord.com/invite/ubGPWb3r).
+For bug reports and feature requests, please use our [feedback portal](https://feedback.planetaryapp.us/bugs). For questions and discussion, join our [Discord server](https://discord.gg/m2fqzENapZ).
 
 ---
 


### PR DESCRIPTION
In the title - replaces the broken Discord Invite in README with the one in the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Discord community invite link in README

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanetaryOrbit/orbit/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->