### PR TITLE
fix discord links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://docs.planetaryapp.us">Documentation</a> ·
   <a href="https://feedback.planetaryapp.us/bugs">Report a Bug</a> ·
   <a href="https://feedback.planetaryapp.us/changelog">Changelog</a> ·
-  <a href="https://discord.com/invite/ubGPWb3r">Discord</a>
+  <a href="https://discord.com/invite/mWqdZmEkDc">Discord</a>
 </div>
 
 ---
@@ -238,7 +238,7 @@ Contributions are welcome and appreciated. Whether you're fixing a bug, improvin
 3. **Test** your changes locally before submitting.
 4. **Open a Pull Request** with a clear description of what you've changed and why.
 
-For bug reports and feature requests, please use our [feedback portal](https://feedback.planetaryapp.us/bugs). For questions and discussion, join our [Discord server](https://discord.com/invite/ubGPWb3r).
+For bug reports and feature requests, please use our [feedback portal](https://feedback.planetaryapp.us/bugs). For questions and discussion, join our [Discord server](https://discord.com/invite/mWqdZmEkDc).
 
 ---
 


### PR DESCRIPTION
not all discord links were changed in the last change, some were still broken, which were fixed in this pr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Discord community invite link in the README to ensure users have the correct community access information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanetaryOrbit/orbit/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->