### PR TITLE
Fixed quota number on profile

### DIFF
--- a/components/profile/quotas.tsx
+++ b/components/profile/quotas.tsx
@@ -5,7 +5,6 @@ import {
   ProfileSection,
 } from "@/components/profile/shell";
 import { IconChartBar, IconUsers, IconBriefcase, IconUser } from "@tabler/icons-react";
-import Tooltip from "@/components/tooltip";
 
 type QuotaWithLinkage = Quota & {
   currentValue?: number;
@@ -111,7 +110,7 @@ export function QuotasProgress({
           const pct = getQuotaPercentage(quota) || 0;
           const isComplete = pct >= 100;
           const barWidth = Math.min(pct, 100);
-          const currentVal = quota.currentValue !== undefined ? quota.currentValue : 0;
+          const currentVal = Math.round(barWidth / 100 * (quota.value != null ? quota.value : 0)); // eh, rudimentary workaround but works and thats all that matters  
           return (
             <div key={quota.id} className="py-3.5">
               <div className="mb-2 flex items-start justify-between gap-3">

--- a/components/profile/quotas.tsx
+++ b/components/profile/quotas.tsx
@@ -110,7 +110,9 @@ export function QuotasProgress({
           const pct = getQuotaPercentage(quota) || 0;
           const isComplete = pct >= 100;
           const barWidth = Math.min(pct, 100);
-          const currentVal = Math.round(barWidth / 100 * (quota.value != null ? quota.value : 0)); // eh, rudimentary workaround but works and thats all that matters  
+          const currentVal = quota.currentValue != null
+            ? quota.currentValue
+            : Math.round((pct / 100) * (quota.value ?? 0));
           return (
             <div key={quota.id} className="py-3.5">
               <div className="mb-2 flex items-start justify-between gap-3">


### PR DESCRIPTION
Fixed the "0" number appearing on the quota while they had some quota done, even tho it had the bar which had visual impact, a **not** *so precise* number is always welcomed.

| Before | After |
|--------|-------|
| <img width="1032" height="130" alt="Screenshot_20260708_111422" src="https://github.com/user-attachments/assets/5dc6f7fe-d605-47f6-a103-3ccd3468a61a" /> | <img width="1024" height="129" alt="Screenshot_20260708_111310" src="https://github.com/user-attachments/assets/6689180c-f348-4dd6-b98f-73d7a6bd956c" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the displayed quota usage values so they now better match the progress bar and are rounded consistently.
  * Removed an unnecessary UI import to keep the component leaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->