### PR TITLE
Fix: mark Forms as coming soon and disable toggle

### DIFF
--- a/components/settings/general/form.tsx
+++ b/components/settings/general/form.tsx
@@ -23,11 +23,17 @@ const Forms: FC<props> = (props) => {
         </div>
         <div>
           <p className="text-sm font-medium text-zinc-900 dark:text-white">Forms</p>
-          <p className="text-xs text-zinc-500 dark:text-zinc-400">Create, customize, and manage workspace forms for collecting structured data, submissions, and user input across your workspace</p>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">Create, customize, and manage workspace forms for collecting structured data, submissions, and user input across your workspace (<strong>Coming Soon</strong>)</p>
         </div>
       </div>
-      <SwitchComponenet
+      {/*<SwitchComponenet
         checked={workspace.settings?.policiesEnabled}
+        label=""
+        classoverride="mt-0"
+      />*/}
+      <SwitchComponenet
+        checked={false}
+        disabled
         label=""
         classoverride="mt-0"
       />


### PR DESCRIPTION
The Forms FF was added in #154 and it seems was not disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Forms section to indicate the feature is “Coming Soon.”
* **UI Changes**
  * Disabled the related toggle so it no longer appears as an active setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->