### PR TITLE
Fix redirectUri for roblox oauth

### DIFF
--- a/pages/api/auth/roblox/start.ts
+++ b/pages/api/auth/roblox/start.ts
@@ -15,7 +15,7 @@ export default async function handler(req: AuthenticatedRequest, res: NextApiRes
 	let clientId: string | undefined;
 	let redirectUri: string | undefined;
 	clientId = process.env.ROBLOX_CLIENT_ID;
-	redirectUri = `${process.env.PLANETARY_CLOUD_URL ? `https://${process.env.PLANETARY_CLOUD_URL}` : process.env.NEXTAUTH_URL || process.env.PUBLIC_URL}/api/auth/discord/callback`;
+	redirectUri = `${process.env.PLANETARY_CLOUD_URL ? `https://${process.env.PLANETARY_CLOUD_URL}` : process.env.NEXTAUTH_URL || process.env.PUBLIC_URL}/api/auth/roblox/callback`;
   if (!clientId || !redirectUri) {
 		try {
 			const configs = await prisma.instanceConfig.findMany({


### PR DESCRIPTION
Not sure if this is right, but orbit is trying to use the discord redirect URL for roblox oauth

This is basically everything that i changed

Or is it like this on purpose?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Roblox sign-in flow to redirect users to the appropriate callback endpoint.
  * Improved successful completion of Roblox OAuth authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->