### PR TITLE
Remove "Search from Sidebar" from 404 page

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -69,8 +69,6 @@ export default function Error() {
                   Report an issue
                 </Link>
               </div>
-
-              <p className="mt-4 text-sm text-zinc-500">Or try searching from the sidebar.</p>
             </div>
           </div>
         </motion.div>


### PR DESCRIPTION
You can't search from the sidebar in Orbit, so I'm not too sure why it's on the 404 page. 

(Fun fact: I was the original creator of the 404 page in Orbit!! Amazing, right?? I'm so honored.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the sidebar search suggestion from the 404 page for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->