### PR TITLE
Updated Vercel section to reflect about support drop for newer version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ The fastest and easiest way to run Orbit is through **Planetary Cloud** — our 
 > 
 > Vercel's serverless architecture introduces real limitations that affect Orbit's reliability — including cold starts, execution timeouts, and constraints on long-running processes like session handling and activity tracking. You may run into hard-to-debug issues that simply don't exist on Planetary Cloud.
 >
-> Since v2.1.11beta.1, Vercel is not supported anymore, and you won't receive any further updates after v2.1.10beta21. The reason of the support drop is because of server-less infrastructure that Vercel has, affecting memory caching. More information can be found in the latest update announcement ([Discord Announcement](https://discord.com/channels/1348101138670682156/1363239258659487864/1534022285453951087)).
+> Vercel support ended with v2.1.11beta.1. Version v2.1.10beta21 is the last Vercel-supported release. Later releases do not receive Vercel support because Vercel's serverless infrastructure limits memory caching.
+> More information can be found in the latest update announcement ([Discord Announcement](https://discord.com/channels/1348101138670682156/1363239258659487864/1534022285453951087)).
 >
 > **[Planetary Cloud](https://planetaryapp.us) is free, purpose-built for Orbit, and works out of the box — no configuration needed.** We can't guarantee a great experience on Vercel, and support for Vercel-specific issues is limited.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The fastest and easiest way to run Orbit is through **Planetary Cloud** — our 
 > 
 > Vercel's serverless architecture introduces real limitations that affect Orbit's reliability — including cold starts, execution timeouts, and constraints on long-running processes like session handling and activity tracking. You may run into hard-to-debug issues that simply don't exist on Planetary Cloud.
 >
-> Since v2.1.11beta.1, Vercel is not supported anymore, and you won't receive any further updates after v2.1.10beta21. The reason of the support drop is because of server-less infrastructure that Vercel has, affecting memory caching. More information can be found in the latest update announcement ([Discord Announcement](https://discord.com/channels/1348101138670682156/1363239258659487864/1534022285453951087))
+> Since v2.1.11beta.1, Vercel is not supported anymore, and you won't receive any further updates after v2.1.10beta21. The reason of the support drop is because of server-less infrastructure that Vercel has, affecting memory caching. More information can be found in the latest update announcement ([Discord Announcement](https://discord.com/channels/1348101138670682156/1363239258659487864/1534022285453951087)).
 >
 > **[Planetary Cloud](https://planetaryapp.us) is free, purpose-built for Orbit, and works out of the box — no configuration needed.** We can't guarantee a great experience on Vercel, and support for Vercel-specific issues is limited.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The fastest and easiest way to run Orbit is through **Planetary Cloud** — our 
 > 
 > Vercel's serverless architecture introduces real limitations that affect Orbit's reliability — including cold starts, execution timeouts, and constraints on long-running processes like session handling and activity tracking. You may run into hard-to-debug issues that simply don't exist on Planetary Cloud.
 >
+> Since v2.1.11beta.1, Vercel is not supported anymore, and you won't receive any further updates after v2.1.10beta21. The reason of the support drop is because of server-less infrastructure that Vercel has, affecting memory caching. More information can be found in the latest update announcement ([Discord Announcement](https://discord.com/channels/1348101138670682156/1363239258659487864/1534022285453951087))
+>
 > **[Planetary Cloud](https://planetaryapp.us) is free, purpose-built for Orbit, and works out of the box — no configuration needed.** We can't guarantee a great experience on Vercel, and support for Vercel-specific issues is limited.
 
 Prefer to host on your own Vercel account? Deploy in seconds:


### PR DESCRIPTION
Since the v2.1.11beta.1 update, Vercel support has been dropped, but readme does not talk about the support drop, so I just fixed that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guidance to note that Vercel is unsupported starting with v2.1.11beta.1.
  * Clarified the final supported version and potential memory-caching issues.
  * Added a link to the related announcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->