### PR TITLE
Update Docker & Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,27 @@
-FROM node:22-alpine
+FROM oven/bun:1-alpine
 
 ARG NODE_OPTIONS="--max-old-space-size=1536"
 ENV NODE_OPTIONS="${NODE_OPTIONS}"
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Install pnpm (version pinned by packageManager in package.json)
-RUN corepack enable
-
-# Create app directory
 WORKDIR /usr/src/app
 
-# Install app dependencies
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-# Copy Prisma schema
+# Install dependencies
+COPY package.json bun.lock ./
 COPY prisma ./prisma/
 
-# Install dependencies (pnpm store cached across builds)
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile
+RUN bun install --frozen-lockfile
 
-# Generate Prisma client for the specific platform
-RUN pnpm exec prisma generate
+# Generate Prisma client
+RUN bunx prisma generate
 
-# Bundle app source
+# Copy application source
 COPY . .
 
-# Build the app (Next.js cache persisted across builds)
+# Build Next.js app
 RUN --mount=type=cache,target=/usr/src/app/.next/cache \
-  pnpm run build
+    bun run build
 
-# Expose port 3000
 EXPOSE 3000
 
-# Start the app
-CMD ["pnpm", "run", "start"]
+CMD ["bun", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ services:
   orbit:
     restart: "unless-stopped"
     tty: true
-    build: "."
+    build:
+      context: .
+      args:
+        CACHE_BUST: ${CACHE_BUST:-1}
     environment:
       SESSION_SECRET: ${SESSION_SECRET}
       DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}}


### PR DESCRIPTION
Fairly simple change. Migrate from pnpm to bun inside of the Dockerfile, and also make it so it rebuilds every time, so when i do
```
docker compose down
git pull
docker compose up -d
```
I get the update, and don't have to tack on 15,000 arguments to get it to recompile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application container to use Bun for dependency installation, builds, and startup.
  * Simplified container setup by removing pnpm-specific configuration.
  * Added configurable build cache invalidation for the application service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->